### PR TITLE
add transformation params as its required since Directus 10.6.3

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ export default (router, { services, env }) => {
       // Resolve all streams to an array
       streamAttachments = await Promise.allSettled(
         fileIDS.map(function (id) {
-          return assetsService.getAsset(id, {});
+          return assetsService.getAsset(id, {transformationParams: {}});
         })
       );
 


### PR DESCRIPTION
Generation of attachment files with Directus files by param `files` fail with `TypeError: Cannot read properties of undefined (reading 'transforms')`, see issue https://github.com/ryntab/Directus-Mailer/issues/9